### PR TITLE
ability to optionally override the current theme's default font weight for the text label to bold

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -88,6 +88,9 @@
         <entry name="fontSizeScale" type="Double">
             <default>1</default>
         </entry>
+        <entry name="boldFontWeight" type="Bool">
+            <default>true</default>
+        </entry>
     </group>
 
     <group name="MouseControl">

--- a/package/contents/ui/config/ConfigAppearance.qml
+++ b/package/contents/ui/config/ConfigAppearance.qml
@@ -19,6 +19,7 @@ Item {
 
     property alias cfg_iconAndTextSpacing: iconAndTextSpacing.value
     property alias cfg_fontSizeScale: fontSizeScale.value
+    property alias cfg_boldFontWeight: boldFontWeight.checked
 
     PlasmaCore.DataSource {
         id: executableDS
@@ -186,6 +187,11 @@ Item {
             Layout.columnSpan: 2
         }
 
+        CheckBox {
+            id: boldFontWeight
+            text: i18n("Bold text")
+        }
+
         GridLayout {
             columns: 2
 
@@ -214,8 +220,9 @@ Item {
                 minimumValue: 0
                 maximumValue: 3
             }
+
         }
-        
+
     }
-    
+
 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -50,6 +50,7 @@ Item {
     property double iconAndTextSpacing: plasmoid.configuration.iconAndTextSpacing
     property bool slidingIconAndText: plasmoid.configuration.slidingIconAndText
     property double fontPixelSize: theme.defaultFont.pixelSize * plasmoid.configuration.fontSizeScale
+    property bool fontBold: plasmoid.configuration.boldFontWeight
 
     property bool noWindowVisible: true
     property bool currentWindowMaximized: false
@@ -177,6 +178,7 @@ Item {
         text: i18n('Plasma Desktop')
         font.pixelSize: fontPixelSize
         font.pointSize: -1
+        font.weight: fontBold ? Font.Bold : theme.defaultFont.weight
         width: parent.width - noWindowTextMargin * 2
         elide: Text.ElideRight
         visible: noWindowVisible && plasmoid.configuration.showWindowTitle
@@ -258,6 +260,7 @@ Item {
                 visible: plasmoid.configuration.showWindowTitle
                 font.pixelSize: fontPixelSize
                 font.pointSize: -1
+                font.weight: fontBold ? Font.Bold : theme.defaultFont.weight
 
                 onTextChanged: {
                     font.pixelSize = fontPixelSize


### PR DESCRIPTION
When using the new global menu in KDE 5.9 along with this applet, there is no visual distinction between the application title/name and the interactive menubar.  This fixes that, and implements an option so the user can choose their desired behavior.